### PR TITLE
Remove Plural check + add Chinese summon cleanup

### DIFF
--- a/PetRenamer/PetNicknames/Services/ServiceWrappers/StringHelperWrapper.cs
+++ b/PetRenamer/PetNicknames/Services/ServiceWrappers/StringHelperWrapper.cs
@@ -310,7 +310,8 @@ internal class StringHelperWrapper : IStringHelper
                 "サモン・", 
                 "Summon ", 
                 "Invocation ", 
-                "-Beschwörung"
+                "-Beschwörung",
+                "召唤"
             ]);
     
     public string ToVector3String(Vector3 vector)

--- a/PetRenamer/PetNicknames/Services/ServiceWrappers/Structs/PetSheetData.cs
+++ b/PetRenamer/PetNicknames/Services/ServiceWrappers/Structs/PetSheetData.cs
@@ -79,7 +79,6 @@ internal readonly struct PetSheetData : IPetSheetData
         int         modelId        = (int)model.Value.RowId;
         int         legacyModelId  = model.Value.Model;
         string      singular       = companion.Singular.ExtractText();
-        string      plural         = companion.Plural.ExtractText();
         PetSkeleton petSkeleton    = new PetSkeleton((uint)modelId, SkeletonType.Minion);
         
         if (legacyModelId == 0)
@@ -87,7 +86,7 @@ internal readonly struct PetSheetData : IPetSheetData
             return null;
         }
         
-        if (singular.IsNullOrWhitespace() || plural.IsNullOrWhitespace())
+        if (singular.IsNullOrWhitespace())
         {
             return null;
         }


### PR DESCRIPTION
o/

**1. Remove the `Plural` check when parsing the Companion sheet**

JA/CN/KR have no grammatical plural and leave the `Plural` column empty for every companion, so the check drops every minion and names can't be resolved. The languages that do have plurals (EN/DE/FR) have no row with a `Singular` but no `Plural`, so `Singular` alone is an equally strict check and the result is identical there. The `Plural` check is redundant where it works and breaks where it doesn't, so it's removed.

**2. Add `召唤` to `CleanupString`**

CN summon actions are formatted as `<name>召唤` (e.g. `宝石兽召唤`), so `召唤` is added to the strip list to recover the base name for castbar replacement. No effect on other languages.